### PR TITLE
changed audio declarations to expressions to eliminate play2 and play…

### DIFF
--- a/javascripts/audio.js
+++ b/javascripts/audio.js
@@ -1,17 +1,17 @@
 "use strict";
 
-function play() {
+var play = function () {
   var audio = document.getElementById("audio");
   audio.play("/audio/slap.mp3");
 }
 
-function play2() {
+var play2 = function () {
   var audio = document.getElementById("audio2");
   audio.play("/audio/vo_anno_you_suck.wav");
 }
 
 
-function play3() {
+var play3 = function () {
   var audio = document.getElementById("audio3");
   audio.play("/audio/Cheering%202-SoundBible.com-457490617.mp3");
 }


### PR DESCRIPTION
This corrects the `play2` and `play3` errors. Changed function declarations to expressions in audio.js file.